### PR TITLE
add 9.6.2 and 9.6.3

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 versions_list=(
+  9.6.3
+  9.6.2
   9.6.1
   9.6.0
   9.5.5


### PR DESCRIPTION
I was able to install 9.6.3 successfully using this plugin even though 9.6.3 wasn't listed. figured others would like to know it's an option.