### PR TITLE
switched \d with [0-9] in list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-versions_list=$(curl -s https://ftp.postgresql.org/pub/source/ | grep -Eoh '>v\d+\.\d+\.\d+<' | sed -e 's/[<>v]//g')
+versions_list=$(curl -s https://ftp.postgresql.org/pub/source/ | grep -Eoh '>v[0-9]+\.[0-9]+\.[0-9]+<' | sed -e 's/[<>v]//g')
 
 versions=""
 
-for version in "${versions_list[@]}"
+for version in ${versions_list}
 do
   versions="${versions} ${version}"
 done


### PR DESCRIPTION
\d didn't work for me on ubuntu 16.04
