### PR TITLE
Change versions_list regular expression to accommodate version number…

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-versions_list=$(curl -s https://ftp.postgresql.org/pub/source/ | grep -Eoh '>v[0-9]+\.[0-9]+\.[0-9]+<' | sed -e 's/[<>v]//g')
+versions_list=$(curl -s https://ftp.postgresql.org/pub/source/ | grep -Eoh '>v[0-9]+\.[0-9]+(\.[0-9]+)?<' | sed -e 's/[<>v]//g')
 
 versions=""
 


### PR DESCRIPTION
…s with only major and minor numbers (no patch number), such as "v10.0".