### PR TITLE
Sort versions numerically (Fixes #11)

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -5,11 +5,9 @@
 
 versions_list=$(
   curl -s https://ftp.postgresql.org/pub/source/ |
-  grep -Eoh '>v[0-9]+\.[0-9]+(\.[0-9]+)?<' | # Find version numbers
-  sed -e 's/[<>v]//g' |                      # Remove the leading v
-  sed -e 's/^[0-9]\./0&/; s/\.\([0-9]\)$/.0\1/; s/\.\([0-9]\)\./.0\1./g; s/\.\([0-9]\)\./.0\1./g' | # Pad each number with leading 0
-  sort |                    # Sort the list
-  sed 's/^0// ; s/\.0/./g') # Remove the padded leading 0
+  grep -Eoh '>v[0-9]+\.[0-9]+(\.[0-9]+)?<'       | # Find version numbers
+  sed -e 's/[<>v]//g'                            | # Remove the leading v
+  sort -t '.' -k 1,1n -k 2,2n -k 3,3n )            # Sort by version number
 
 versions=""
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
-# version sorting recklessly lifted from StackOverflow
-# https://stackoverflow.com/a/21395280/2216771
-
 versions_list=$(
   curl -s https://ftp.postgresql.org/pub/source/ |
   grep -Eoh '>v[0-9]+\.[0-9]+(\.[0-9]+)?<'       | # Find version numbers
   sed -e 's/[<>v]//g'                            | # Remove the leading v
-  sort -t '.' -k 1,1n -k 2,2n -k 3,3n )            # Sort by version number
+  sort -t '.' -k 1n -k 2n -k 3n )                  # Sort by version number
 
 versions=""
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
-versions_list=$(curl -s https://ftp.postgresql.org/pub/source/ | grep -Eoh '>v[0-9]+\.[0-9]+(\.[0-9]+)?<' | sed -e 's/[<>v]//g')
+# version sorting recklessly lifted from StackOverflow
+# https://stackoverflow.com/a/21395280/2216771
+
+versions_list=$(
+  curl -s https://ftp.postgresql.org/pub/source/ |
+  grep -Eoh '>v[0-9]+\.[0-9]+(\.[0-9]+)?<' | # Find version numbers
+  sed -e 's/[<>v]//g' |                      # Remove the leading v
+  sed -e 's/^[0-9]\./0&/; s/\.\([0-9]\)$/.0\1/; s/\.\([0-9]\)\./.0\1./g; s/\.\([0-9]\)\./.0\1./g' | # Pad each number with leading 0
+  sort |                    # Sort the list
+  sed 's/^0// ; s/\.0/./g') # Remove the padded leading 0
 
 versions=""
 
@@ -9,4 +18,4 @@ do
   versions="${versions} ${version}"
 done
 
-echo $versions
+echo "$versions"

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,7 +4,7 @@ versions_list=$(
   curl -s https://ftp.postgresql.org/pub/source/ |
   grep -Eoh '>v[0-9]+\.[0-9]+(\.[0-9]+)?<'       | # Find version numbers
   sed -e 's/[<>v]//g'                            | # Remove the leading v
-  sort -t '.' -k 1n -k 2n -k 3n )                  # Sort by version number
+  sort -t '.' -k 1,1n -k 2,2n -k 3,3n )            # Sort by version number
 
 versions=""
 


### PR DESCRIPTION
I don't know what the best practice is here, but here is one potential fix for version sorting pulled from [this SO answer.](https://stackoverflow.com/a/21395280/2216771)

This chain of commands to pull the list of versions is getting hairy enough that it probably deserves to be pulled out into a couple of function calls. Unfortunately my experience with bash scripting is very limited, so that isn't something I've managed to work out successfully yet. Pointers would be appreciated, but maybe I'll spend some time doing some reading/playing around this weekend or something. At the very least this should get the discussion started.