### PR TITLE
option to load build configure options from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ When installing Postgres using `asdf install`, you can pass custom configure opt
 * `POSTGRES_CONFIGURE_OPTIONS` - use only your configure options
 * `POSTGRES_EXTRA_CONFIGURE_OPTIONS` - append these configure options along with ones that this plugin already uses
 
+These options can be passed at runtime, or set in `~/.asdf-postgres-configure-options`. This file will be sourced at `asdf install` time if it exists.
+
 # How to use (easier version)
 ## Install
 1. Create your .tool-versions file in the project that needs postgres and add `postgres 9.4.7` or whatever version that you want.

--- a/bin/install
+++ b/bin/install
@@ -40,6 +40,8 @@ install_postgres() {
 
 
 construct_configure_options() {
+  load_configure_options
+
   if [ "$POSTGRES_CONFIGURE_OPTIONS" = "" ]; then
     local configure_options="$(os_based_configure_options) --prefix=$install_path"
 
@@ -51,6 +53,19 @@ construct_configure_options() {
   fi
 
   echo "$configure_options"
+}
+
+
+load_configure_options() {
+  local asdf_postgres_configure_options="${HOME}/.asdf-postgres-configure-options"
+
+  if [[ ! -r "$asdf_postgres_configure_options" ]]; then
+    return
+  fi
+
+  set -a
+  source "$asdf_postgres_configure_options"
+  set +a
 }
 
 


### PR DESCRIPTION
This PR provides the ability to load postgres build configuration options from file, as a convenience so I can set them once and have them always applied at `asdf install` time.

Example usage:
```
> echo 'POSTGRES_EXTRA_CONFIGURE_OPTIONS=--with-uuid=e2fs' > ~/.asdf-postgres-configure-options
> asdf install postgres 9.6.12
** Resuming transfer from byte position 24343531
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   389    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (33) HTTP server doesn't seem to support byte ranges. Cannot resume.
Building with options:  --prefix=/Users/user/.asdf/installs/postgres/9.6.12 --with-uuid=e2fs
...
```