### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ _This requires [brew](http://brew.sh) if you're on a mac, or a debian flavored l
     1. ```gcc```
     1. Hit the ok button and it will install.  If it already has it, then you are good.
   * Ubuntu  
-    1. ```sudo apt-get install linux-headers-$(uname -r) build-essential```
+    1. ```sudo apt install linux-headers-$(uname -r) build-essential```
 1. On Ubuntu, you will need libreadline
-  1. ```sudo apt-get install libreadline-dev```
+  1. ```sudo apt install libreadline-dev```
 
 ## Install
 
 ```
-asdf plugin-add postgres https://github.com/smashedtoatoms/asdf-postgres.git
+asdf plugin-add postgres
 ```
 
 ## ASDF options


### PR DESCRIPTION
I cleaned-up ('modernized') two Ubuntu commands and I cleaned-up the `asdf` plugin install command; the Git repo argument is no longer required as this plugin is listed in the official registry, e.g. it's in the output of `asdf plugin-list-all` as `postgres`.