### PR TITLE
Remove macOS homebrew requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Postgresql plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 
 ## Dependencies
-_This requires [brew](http://brew.sh) if you're on a mac, or a debian flavored linux.  If you need it to work on something else, you'll likely need to modify the plugin._  
+_This assumes macOS or a debian flavored linux.  If you need it to work on something else, you'll likely need to modify the plugin._  
 
 1. You will need a compiler.
   * Mac

--- a/bin/install
+++ b/bin/install
@@ -22,9 +22,6 @@ install_postgres() {
     cd $(untar_path $install_type $version $tmp_download_dir)
 
     local configure_options="$(construct_configure_options)"
-    # set in os_based_configure_options
-    # we unset it here because echo-ing changes the return value of the function
-    unset ASDF_PKG_MISSING
 
     echo "Building with options: $configure_options"
     ./configure $configure_options || exit 1
@@ -43,7 +40,7 @@ construct_configure_options() {
   load_configure_options
 
   if [ "$POSTGRES_CONFIGURE_OPTIONS" = "" ]; then
-    local configure_options="$(os_based_configure_options) --prefix=$install_path"
+    local configure_options="--prefix=$install_path"
 
     if [ "$POSTGRES_EXTRA_CONFIGURE_OPTIONS" != "" ]; then
       configure_options="$configure_options $POSTGRES_EXTRA_CONFIGURE_OPTIONS"
@@ -66,39 +63,6 @@ load_configure_options() {
   set -a
   source "$asdf_postgres_configure_options"
   set +a
-}
-
-
-homebrew_package_path() {
-  local package_name=$1
-
-  if [ "$(brew ls --versions $package_name)" = "" ]; then
-    echo ""
-  else
-    echo "$(brew --prefix $package_name)"
-  fi
-}
-
-
-exit_if_homebrew_not_installed() {
-  if [ "$(brew --version 2>/dev/null)" = "" ]; then
-    echo "ERROR: Please install homebrew for OSX"
-    exit 1
-  fi
-}
-
-
-os_based_configure_options() {
-  local operating_system=$(uname -a)
-  local configure_options=""
-
-  if [[ "$operating_system" =~ "Darwin" ]]; then
-    exit_if_homebrew_not_installed
-  else
-    configure_options=""
-  fi
-  
-  echo $configure_options
 }
 
 


### PR DESCRIPTION
The plugin was halting installation on macOS if Homebrew (`brew`) was
not available. However, `brew` was never used during the actual
installation. The plugin compiles PostgreSQL from source downloaded from
the official repository.

Also updated the README to remove references to homebrew.

Fixes #26 (using the suggested patch)