### PR TITLE
Fix list-all results

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,16 +1,7 @@
 #!/usr/bin/env bash
 
-versions_list=$(
-  curl -s https://ftp.postgresql.org/pub/source/        |
-  grep -Eoh '>v[0-9]+(\.[0-9]+(\.[0-9]+)?|beta[0-9]+)/<'| # Find version numbers
-  sed -e 's/[<>v/]//g'                                  | # Remove the leading v
-  sort -t '.' -k 1,1n -k 2,2n -k 3,3n )                   # Sort by version number
-
-versions=""
-
-for version in ${versions_list}
-do
-  versions="${versions} ${version}"
-done
-
-echo "$versions"
+curl -s https://ftp.postgresql.org/pub/source/ |
+    grep -Eoh '>v[0-9]+(\.[0-9]+(\.[0-9]+)?|beta[0-9]+)/<' | # Find version numbers
+    sed -e 's/[<>v/]//g'                                   | # Remove the leading v
+    sort -t '.' -k 1,1n -k 2,2n -k 3,3n                    | # Sort by version number
+    tr '\n' ' '                                              # Replace newlines


### PR DESCRIPTION
The list-all subcommand is returning nothing, but the curl and parse pipeline works when run from the command-line without ASDF, so the empty response list may be caused by the way newlines are being removed. This patch replaces the for loop with a more robust approach using tr.

Related: #38

Before:

```
bin master % asdf list-all postgres | head
```

After:

```
bin master % asdf list-all postgres | head
1.08
1.09
6.0
6.1
6.2
6.3
6.4
6.5
7.0
7.0.1

```