### PR TITLE
Added patch icu68 and uuid-oosp

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,6 +21,8 @@ install_postgres() {
     tar zxf $source_path || exit 1
     cd $(untar_path $install_type $version $tmp_download_dir)
 
+    prepare $version
+
     local configure_options="$(construct_configure_options)"
 
     echo "Building with options: $configure_options"
@@ -33,6 +35,29 @@ install_postgres() {
     mkdir $install_path/data || exit 1
     $install_path/bin/initdb -D $install_path/data || exit 1
   )
+}
+
+
+prepare() {
+  local version=$1
+  local minor=${version%.*}
+  local major=${minor%.*}
+  local minor_integer=$(awk -v x=$minor 'BEGIN{print x*100}')
+  local icu_uconv=$(uconv -V)
+  local icu_version=${icu_uconv##*ICU }
+  local icu_version_major=${icu_version%.*}
+
+  if [ "$(uname)" == "Linux" ] && [ "$icu_version_major" -eq 68 ] && [ "$major" -ge 11 ]; then
+    cd src || exit
+    git apply $HOME/.asdf/plugins/postgres/lib/icu68.patch
+    cd ..
+  fi
+
+  if [ "$(uname)" == "Darwin" ] && [ "$minor_integer" -ge '840' ] && [ "$minor_integer" -le "930" ]; then
+    cd contrib || exit
+    git apply $HOME/.asdf/plugins/postgres/lib/uuid-ossp.patch
+    cd ..
+  fi
 }
 
 

--- a/lib/icu68.patch
+++ b/lib/icu68.patch
@@ -1,0 +1,17 @@
+Regressed by https://github.com/unicode-org/icu/commit/c3fe7e09d844
+
+collationcmds.c:467:51: error: use of undeclared identifier 'TRUE'
+        uloc_toLanguageTag(localename, buf, sizeof(buf), TRUE, &status);
+                                                         ^
+
+--- src/backend/commands/collationcmds.c.orig	2020-09-21 20:47:36 UTC
++++ src/backend/commands/collationcmds.c
+@@ -464,7 +464,7 @@ get_icu_language_tag(const char *localename)
+ 	UErrorCode	status;
+
+ 	status = U_ZERO_ERROR;
+-	uloc_toLanguageTag(localename, buf, sizeof(buf), TRUE, &status);
++	uloc_toLanguageTag(localename, buf, sizeof(buf), true, &status);
+ 	if (U_FAILURE(status))
+ 		ereport(ERROR,
+ 				(errmsg("could not convert locale name \"%s\" to language tag: %s",

--- a/lib/uuid-ossp.patch
+++ b/lib/uuid-ossp.patch
@@ -1,0 +1,11 @@
+--- contrib/uuid-ossp/uuid-ossp.c     2012-07-30 18:34:53.000000000 -0700
++++ contrib/uuid-ossp/uuid-ossp.c     2012-07-30 18:35:03.000000000 -0700
+@@ -9,6 +9,8 @@
+  *-------------------------------------------------------------------------
+  */
+
++#define _XOPEN_SOURCE
++
+ #include "postgres.h"
+ #include "fmgr.h"
+ #include "utils/builtins.h"


### PR DESCRIPTION
This patch need for cooreect build postgres on linux with lates icu
This patch need for correct buuild old version postgres with uuid-oosp

Patch:
- [x] patch icu68 [refs](https://github.com/unicode-org/icu/commit/c3fe7e09d844)
- [x] patch uuid-oosp [refs](https://www.postgresql.org/message-id/05843630-E25D-442A-A6B0-5CA63622A400@likeness.com)

Testing:
- [x] ArchLinux
- [x] macOS Big Sur
- [x] macOS Catalina
- [x] macOS Mojave

