### PR TITLE
Do not assume existence of any non-special parameters in exec-env.

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+PGDATA=${PGDATA:-}
+PGHOST=${PGHOST:-}
+PGPORT=${PGPORT:-}
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}
+
 if [ "$PGDATA" = "" ]; then
   export PGDATA="$ASDF_INSTALL_PATH/data"
 else


### PR DESCRIPTION
When executing exec-env with bash's `nounset` flag enabled, it fails with multiple `unbound variable` errors.


> -u     Treat unset variables and parameters other than
         the special parameters "@" and "*" as an error
         when performing parameter expansion.  If expansion
         is attempted on an unset variable or parameter,
         the shell prints an error message, and, if not
         interactive, exits with a non-zero status.
  
> see:  https://man7.org/linux/man-pages/man1/bash.1.html


This is the case when using asdf-postgres with asdf-direnv with direnv configured with `strict_env=true` (which execs bash with: `set -euo pipefail`).

See original issue here for details:

https://github.com/asdf-community/asdf-direnv/issues/115

Thanks!
