### PR TITLE
$POSTGRES_SKIP_INITDB

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -33,7 +33,9 @@ install_postgres() {
     make || exit 1
     make install || exit 1
     mkdir $install_path/data || exit 1
-    $install_path/bin/initdb -D $install_path/data -U postgres || exit 1
+    if [ "$POSTGRES_SKIP_INITDB" = "" ]; then
+      $install_path/bin/initdb -D $install_path/data -U postgres || exit 1
+    fi
   )
 }
 


### PR DESCRIPTION
This variable set to non empty value skips initdb command which breaks if run with root privileges. It might be necessary to avoid when run ie. in docker build.

Example of usage: https://github.com/dex4er/docker-debian-awscli-postgres/blob/main/Dockerfile#L14
