### PR TITLE
Update README: Add missing package to openSUSE section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sudo dnf install openssl-devel readline-devel zlib-devel libcurl-devel uuid-deve
 
 ```
 sudo zypper install -t pattern devel_basis
-sudo zypper in openssl-devel readline-devel zlib-devel libcurl-devel uuid-devel
+sudo zypper in openssl-devel readline-devel zlib-devel libcurl-devel uuid-devel libuuid-devel
 ```
 
 ## Install


### PR DESCRIPTION
OS: openSUSE Tumbleweed on Windows 10 x86_64
Kernel: 5.15.90.1-microsoft-standard-WSL2

## Current outcome:
`asdf install postgres latest` fails with `error: library 'uuid' is required for E2FS UUID`

## Expected outcome:
`asdf install postgres latest` succeeded without error.

`Success. You can now start the database server using: ...`

## Problem description:
In order to run `asdf install postgres latest` i needed to install one additional package. Sorry, i'm not sure if it is enough to replace `uuid-devel` with `libuuid-devel`. I simply installed `libuuid-devel` additionally and afterwards the `postgres` installation was successful.