### PR TITLE
chore: extract download steps into `bin/download`

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+download_source() {
+  local install_type=$1
+  local version=$2
+  local release_file=$3
+  local download_url
+  download_url=$(get_download_url "$install_type" "$version")
+
+  curl -Lo "$release_file" -C - "$download_url"
+}
+
+get_download_file_path() {
+  local install_type=$1
+  local version=$2
+  local download_path=$3
+  local pkg_name="$download_path/postgresql-${version}.tar.gz"
+
+  echo "$pkg_name"
+}
+
+get_download_url() {
+  local install_type=$1
+  local version=$2
+  echo "https://ftp.postgresql.org/pub/source/v${version}/postgresql-${version}.tar.gz"
+}
+
+mkdir -p "$ASDF_DOWNLOAD_PATH"
+
+release_file=$(get_download_file_path "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_DOWNLOAD_PATH")
+
+# Download tar.gz file to the download directory
+download_source "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$release_file"
+
+# Extract contents of tar.gz file into the download directory
+tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
+
+# Remove the tar.gz file since we don't need to keep it
+rm "$release_file"

--- a/bin/install
+++ b/bin/install
@@ -5,21 +5,10 @@ install_postgres() {
   local version=$2
   local install_path=$3
 
-  if [ "$TMPDIR" = "" ]; then
-    local tmp_download_dir=$(mktemp -d)
-  else
-    local tmp_download_dir=$TMPDIR
-  fi
-
-  local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
-  download_source $install_type $version $source_path
-
   # running this in a subshell
   # because we don't want to disturb current working dir
   (
-    cd $(dirname $source_path)
-    tar zxf $source_path || exit 1
-    cd $(untar_path $install_type $version $tmp_download_dir)
+    cd "$ASDF_DOWNLOAD_PATH"
 
     prepare $version
 
@@ -112,40 +101,4 @@ lib_include_paths() {
     --with-includes='/opt/local/lib:/sw/lib:/usr/local/opt/openssl/include:$homebrew_include_path/usr/local/include:/usr/local/lib:/usr/lib'"
 }
 
-untar_path() {
-  local install_type=$1
-  local version=$2
-  local tmp_download_dir=$3
-
-  if [ "$install_type" = "version" ]; then
-    echo "$tmp_download_dir/postgresql-${version}"
-  else
-    echo "$tmp_download_dir/postgresql-${version}"
-  fi
-}
-
-download_source() {
-  local install_type=$1
-  local version=$2
-  local download_path=$3
-  local download_url=$(get_download_url $install_type $version)
-
-  curl -Lo $download_path -C - $download_url
-}
-
-get_download_file_path() {
-  local install_type=$1
-  local version=$2
-  local tmp_download_dir=$3
-  local pkg_name="postgresql-${version}.tar.gz"
-
-  echo "$tmp_download_dir/$pkg_name"
-}
-
-get_download_url() {
-  local install_type=$1
-  local version=$2
-  echo "https://ftp.postgresql.org/pub/source/v${version}/postgresql-${version}.tar.gz"
-}
-
-install_postgres $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_postgres "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
As https://asdf-vm.com/plugins/create.html#scripts-overview describes, plugins should implement a `bin/download` script that downloads the source code. This commit moves the download functionality from `bin/install` into `bin/download`.

The tarball and source code will now be extracted in the default `asdf` download directory (e.g. `~/.asdf/downloads/postgres/<version>`) rather than some arbitary temporary directory. In addition, `asdf` will also properly clean up the download directory unless the `always_keep_download` setting is set.

Closes #72