### PR TITLE
Export PKG_CONFIG_PATH on macos runner for pkg-config to find icu4c

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v3
         with:
           command: postgres --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,21 @@ on:
     - cron: "0 0 * * *" # daily at midnight
 
 jobs:
-  plugin_test:
-    name: asdf plugin test
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+  plugin_test_ubuntu:
+    name: asdf plugin test (ubuntu)
+    runs-on: ubuntu-latest
     steps:
-      - name: asdf_plugin_test
+      - name: asdf_plugin_test_ubuntu
         uses: asdf-vm/actions/plugin-test@v3
+        with:
+          command: postgres --version
+  plugin_test_macos:
+    name: asdf plugin test (macos)
+    runs-on: macos-latest
+    steps:
+      - name: asdf_plugin_test_macos
+        uses: asdf-vm/actions/plugin-test@v3
+        env:
+          PKG_CONFIG_PATH: "/usr/local/opt/icu4c/lib/pkgconfig"
         with:
           command: postgres --version


### PR DESCRIPTION
This PR fixes the CI which has been broken since 3 months ago when postgres v16 was released. This closes #77 where the background is at, and the poc is at https://github.com/sato11/asdf-postgres/pull/1 where you can see that the build passes.

Actually I'm not 100% confident if it is the best solution possible but I'm proposing it anyway. I appreciate any feedback. What do you think?