### PR TITLE
Replace the status badge of GHA workflow in accordance with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# asdf-postgres ![Build](https://github.com/smashedtoatoms/asdf-postgres/workflows/Build/badge.svg?branch=master)
+# asdf-postgres [![Build](https://github.com/smashedtoatoms/asdf-postgres/actions/workflows/build.yml/badge.svg)](https://github.com/smashedtoatoms/asdf-postgres/actions/workflows/build.yml)
 
 Postgresql plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 


### PR DESCRIPTION
The nightly build of the master branch has been fixed a couple of days ago (#78), yet this status badge at the top of README still indicates it's failing.

The previous version of the badge link seems not documented, while the one that's documented[^1] does show it's passing. So let's just replace it.

The notation is taken from the "Create status badge" button at the dashboard[^2]. The `?branch=master` has been removed since the badge points to the default branch by default.

[^1]: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge
[^2]: https://github.com/smashedtoatoms/asdf-postgres/actions/workflows/build.yml