### PR TITLE
Revert "Fix problem with OpenSSL and Readline detection"

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,14 +1,9 @@
 #!/usr/bin/env bash
 
-: ${ASDF_DATA_DIR:=${HOME}/.asdf}
-: ${ASDF_PLUGIN_PATH:=${ASDF_DATA_DIR}/plugins/redis}
-
 install_postgres() {
   local install_type=$1
   local version=$2
   local install_path=$3
-
-  local configure_options
 
   # running this in a subshell
   # because we don't want to disturb current working dir
@@ -17,7 +12,7 @@ install_postgres() {
 
     prepare $version
 
-    configure_options="$(construct_configure_options)" || exit 1
+    local configure_options="$(construct_configure_options)"
 
     echo "Building with options: $configure_options"
     ./configure $configure_options || exit 1
@@ -44,13 +39,13 @@ prepare() {
 
   if [ "$(uname)" == "Linux" ] && [ "$icu_version_major" -eq 68 ] && [ "$major" -ge 11 ]; then
     cd src || exit
-    git apply "${ASDF_PLUGIN_PATH}/lib/icu68.patch"
+    git apply $HOME/.asdf/plugins/postgres/lib/icu68.patch
     cd ..
   fi
 
   if [ "$(uname)" == "Darwin" ] && [ "$minor_integer" -ge '840' ] && [ "$minor_integer" -le "930" ]; then
     cd contrib || exit
-    git apply "${ASDF_PLUGIN_PATH}/lib/uuid-ossp.patch"
+    git apply $HOME/.asdf/plugins/postgres/lib/uuid-ossp.patch
     cd ..
   fi
 }
@@ -58,14 +53,12 @@ prepare() {
 construct_configure_options() {
   load_configure_options
 
-  local configure_options
-
   if [ "$POSTGRES_CONFIGURE_OPTIONS" = "" ]; then
-    configure_options="--prefix=$install_path \
+    local configure_options="--prefix=$install_path \
     --with-uuid=e2fs \
     --with-openssl \
     --with-zlib \
-    $(lib_include_paths)" || return 1
+    $(lib_include_paths)"
 
     if [ "$POSTGRES_EXTRA_CONFIGURE_OPTIONS" != "" ]; then
       configure_options="$configure_options $POSTGRES_EXTRA_CONFIGURE_OPTIONS"
@@ -90,80 +83,22 @@ load_configure_options() {
 }
 
 lib_include_paths() {
-  local openssl_prefix
-  local readline_prefix
-  local include_paths
-  local lib_paths
-  local error
+  if [ -d "$HOMEBREW_PREFIX/opt" ]; then
+    local homebrew_lib_path
+    local homebrew_include_path
+    homebrew_lib_path="$HOMEBREW_PREFIX/opt/openssl/lib"
+    homebrew_include_path="$HOMEBREW_PREFIX/opt/openssl/include:/opt/homebrew/include"
 
-  # Linux and also MacPorts
-  openssl_prefix=$(pkg-config --variable=prefix libcrypto 2>/dev/null);
-  readline_prefix=$(pkg-config --variable=prefix readline 2>/dev/null);
+    while read -r dir ; do
+      homebrew_lib_path="$homebrew_lib_path:$dir/lib"
+      homebrew_include_path="$homebrew_include_path:$dir/include"
+    done <<<"$(ls -d $HOMEBREW_PREFIX/opt/openssl@* | sort -rV)"
 
-  include_paths=""
-  lib_paths=""
-
-  if [[ -n $openssl_prefix ]]; then
-    include_paths="$openssl_prefix/include"
-    lib_paths="$openssl_prefix/lib"
+    homebrew_lib_path="$homebrew_lib_path:$HOMEBREW_PREFIX/openssl/lib:$HOMEBREW_PREFIX/libressl/lib:$HOMEBREW_PREFIX/lib:"
+    homebrew_include_path="$homebrew_include_path:$HOMEBREW_PREFIX/openssl/include:$HOMEBREW_PREFIX/libressl/include:$HOMEBREW_PREFIX/include:"
   fi
-
-  if [[ -n $readline_prefix ]]; then
-    include_paths+=":$readline_prefix/include"
-    lib_paths+=":$readline_prefix/lib"
-  fi
-
-  # Attempt to find HOMEBREW_PREFIX if the var is not set
-  if [[ -z $HOMEBREW_PREFIX ]]; then
-    HOMEBREW_PREFIX=$(brew --prefix 2>/dev/null)
-  fi
-
-  if [[ -d "$HOMEBREW_PREFIX/opt" ]]; then
-    export HOMEBREW_PREFIX
-    include_paths+=":$HOMEBREW_PREFIX/lib"
-    lib_paths+=":$HOMEBREW_PREFIX/include"
-  fi
-
-  # Use OpenSSL from Homebrew
-  if [[ -z $openssl_prefix ]]; then
-    if [[ -d "$HOMEBREW_PREFIX/opt/openssl@3" ]]; then
-      openssl_prefix="$HOMEBREW_PREFIX/opt/openssl@3"
-    elif [[ -d "$HOMEBREW_PREFIX/opt/openssl" ]]; then
-      openssl_prefix="$HOMEBREW_PREFIX/opt/openssl"
-    elif [[ -d "$HOMEBREW_PREFIX/opt/libressl" ]]; then
-      openssl_prefix="$HOMEBREW_PREFIX/opt/libressl"
-    fi
-
-    include_paths+=":$openssl_prefix/include"
-    lib_paths+=":$openssl_prefix/lib"
-  fi
-
-  # Use Readline from Homebrew
-  if [[ -z $readline_prefix ]]; then
-    if [[ -d "$HOMEBREW_PREFIX/opt/readline" ]]; then
-      readline_prefix="$HOMEBREW_PREFIX/opt/readline"
-      include_paths+=":$readline_prefix/include"
-      lib_paths+=":$readline_prefix/lib"
-    fi
-  fi
-
-  error=false
-  if [[ -z $openssl_prefix ]]; then
-    echo "Could not find OpenSSL!" >&2
-    error=true
-  fi
-
-  if [[ -z $readline_prefix ]]; then
-    echo "Could not find Readline!" >&2
-    error=true
-  fi
-
-  if [[ $error == true ]]; then
-    return 1
-  fi
-
-  echo "--with-libraries=$lib_paths:/opt/local/lib:/sw/lib:/usr/local/lib:/usr/lib \
-    --with-includes=$include_paths:/opt/local/lib:/sw/lib:/usr/local/include:/usr/local/lib:/usr/lib"
+  echo "--with-libraries='/opt/local/lib:/sw/lib:/usr/local/opt/openssl/lib:$homebrew_lib_path/usr/local/lib:/usr/lib' \
+    --with-includes='/opt/local/lib:/sw/lib:/usr/local/opt/openssl/include:$homebrew_include_path/usr/local/include:/usr/local/lib:/usr/lib'"
 }
 
 install_postgres "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
Reverts smashedtoatoms/asdf-postgres#81

Received complains that this broke pipelines:

It seems that [this](https://github.com/smashedtoatoms/asdf-postgres/pull/81) MR broke our pipeline since it was deployed yesterday.

We did not have any problem with OpenSSL or ReadLine, even if all of us are using mac. I guess the way it was fixed for some people broke it for others.

Personally, I am using an M2 Macbook Pro with macOS Sonoma, but other colleagues are using M1.