### PR TITLE
fix: update docs and icu in actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,14 @@ jobs:
   plugin_test_macos:
     name: asdf plugin test (macos)
     runs-on: macos-latest
+    env:
+      POSTGRES_CONFIGURE_OPTIONS: "--without-icu"
     steps:
+      - name: add uic bin to path
+        run: echo "/opt/homebrew/opt/icu4c/bin" >> $GITHUB_PATH
+      - name: install dependencies
+        run: brew install gcc readline zlib curl ossp-uuid icu4c pkg-config
       - name: asdf_plugin_test_macos
         uses: asdf-vm/actions/plugin-test@v3
-        env:
-          PKG_CONFIG_PATH: "/usr/local/opt/icu4c/lib/pkgconfig"
         with:
           command: postgres --version

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ you prefer. There are some suggestions below._
 ### Mac
 
 ```sh
-brew install gcc readline zlib curl ossp-uuid icu4c
+brew install gcc readline zlib curl ossp-uuid icu4c pkg-config
 ```
 
 If you are on Apple silicon, you may need to set the HOMEBREW_PREFIX environment
@@ -34,7 +34,7 @@ with icu4c.  Often they can be resolved by setting your PKG_CONFIG_PATH
 environment variable to reference where your linked libs live.  For example:
 
 ```sh
-brew install gcc readline zlib curl ossp-uuid icu4c
+brew install gcc readline zlib curl ossp-uuid icu4c pkg-config
 export PKG_CONFIG_PATH="/opt/homebrew/bin/pkg-config:$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix curl)/lib/pkgconfig:$(brew --prefix zlib)/lib/pkgconfig"
 ```
 

--- a/bin/install
+++ b/bin/install
@@ -89,7 +89,7 @@ lib_include_paths() {
     homebrew_lib_path="$HOMEBREW_PREFIX/opt/openssl/lib"
     homebrew_include_path="$HOMEBREW_PREFIX/opt/openssl/include:/opt/homebrew/include"
 
-    while read -r dir ; do
+    while read -r dir; do
       homebrew_lib_path="$homebrew_lib_path:$dir/lib"
       homebrew_include_path="$homebrew_include_path:$dir/include"
     done <<<"$(ls -d $HOMEBREW_PREFIX/opt/openssl@* | sort -rV)"


### PR DESCRIPTION
icu is an absolute tire fire on mac right now.  I disabled it in actions because I don't have time to chase it down.  I updated the docs to reflect the need for pkg-config because it mostly makes things easier. Thank the postgres team and apple for making this a pain in the taint.