### PR TITLE
Update asdf plugin installation command snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sudo zypper in openssl-devel readline-devel zlib-devel libcurl-devel uuid-devel 
 ## Install
 
 ```sh
-asdf plugin-add postgres
+asdf plugin add postgres https://github.com/smashedtoatoms/asdf-postgres.git
 ```
 
 ## ASDF options


### PR DESCRIPTION
I was setting up a new machine and installing the plug in but looks like it's not correct. This PR corrects the code snippet for installing the asdf plugin;