### PR TITLE
Include `bison` and `flex` as dependencies for Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ brew install gcc readline zlib curl ossp-uuid icu4c pkg-config
 export PKG_CONFIG_PATH="/opt/homebrew/bin/pkg-config:$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix curl)/lib/pkgconfig:$(brew --prefix zlib)/lib/pkgconfig"
 ```
 
-### Ubuntu
+### Debian/ Ubuntu
 
 ```sh
-sudo apt-get install linux-headers-$(uname -r) build-essential libssl-dev \
+sudo apt-get install linux-headers-$(uname -r) build-essential bison flex libssl-dev \
 libreadline-dev zlib1g-dev libcurl4-openssl-dev uuid-dev icu-devtools libicu-dev
 ```
 
-### Ubuntu (WSL)
+### Debian/ Ubuntu (WSL)
 
 ```sh
-sudo apt-get install build-essential libssl-dev libreadline-dev zlib1g-dev \
+sudo apt-get install build-essential bison flex libssl-dev libreadline-dev zlib1g-dev \
 libcurl4-openssl-dev uuid-dev icu-devtools libicu-dev
 ```
 


### PR DESCRIPTION
I just installed Debian 13 and tried to install postgres latest and got a few errors related to missing dependencies. I think we should clarify that those dependencies are now [required](https://www.postgresql.org/docs/current/install-requirements.html#:~:text=Flex%20and%20Bison%20are%20required.%20Other%20lex%20and%20yacc%20programs%20cannot%20be%20used.%20Bison%20needs%20to%20be%20at%20least%20version%202.3.) since v17 in the README. I also took the liberty of mentioning Debian in the installation instructions, along with Ubuntu, just to be more explicit. 